### PR TITLE
Rewrite level goal texts to be spot-on and clearer, fixes #67

### DIFF
--- a/levels/99luft/99luftballons.xml
+++ b/levels/99luft/99luftballons.xml
@@ -4,7 +4,7 @@
         <title>99 Luftballons</title>
         <author>Klaas van Gend</author>
         <license>MIT</license>
-        <description>Pop all balloons. This level is based on some conversations at T-Dose 2010.</description>
+        <description>Pop all balloons.</description>
         <date>5/3/11</date>
     </levelinfo>
     <toolbox>

--- a/levels/angry/birds1.xml
+++ b/levels/angry/birds1.xml
@@ -4,7 +4,7 @@
         <title>Pigs on top!</title>
         <author>Klaas van Gend</author>
         <license/>
-        <description>They are Angry Birds for what? Just a few eggs? Kill one bird and four eggs with one stone (dynamite).</description>
+        <description>Kill the angry-looking bird and break four eggs!</description>
         <date>6/15/11</date>
     </levelinfo>
     <toolbox>
@@ -100,7 +100,7 @@
             <object width="0.600" X="7.908" Y="2.661" height="0.600" type="Balloon" ID="Mr.A.Bird" angle="0.000">
                 <property key="ImageName">yellow_bird;BalloonPoof;Empty;Empty</property>
                 <property key="Mass">6</property>
-                <tooltip>Looks like a bird. And he's angry.</tooltip>
+                <tooltip>This bird looks angry. It it rather frail, however.</tooltip>
             </object>
             <object width="0.440" X="1.289" Y="2.976" height="0.440" type="PostIt" angle="0.000">
                 <property key="page1">I hate Angry Birds!</property>

--- a/levels/angry/birds2.xml
+++ b/levels/angry/birds2.xml
@@ -4,7 +4,7 @@
         <title>The Birds Strike Back!</title>
         <author>Klaas van Gend</author>
         <license/>
-        <description>Make three birds and three eggs do poof.</description>
+        <description>Keep Mr. Stick Figure safe, kill three birds and break three eggs.</description>
         <date>6/15/11</date>
     </levelinfo>
     <toolbox>
@@ -89,7 +89,7 @@
             <object width="3.874" X="2.374" Y="0.687" height="1.000" type="LeftRamp" angle="0.000"/>
             <object width="0.600" X="7.511" Y="2.691" height="0.600" type="Balloon" ID="Mr.A.Bird" angle="0.000">
                 <property key="ImageName">yellow_bird;BalloonPoof;Empty;Empty</property>
-                <tooltip>Looks like a bird. And he's angry.</tooltip>
+                <tooltip>This bird looks angry. It it rather frail, however.</tooltip>
                 <property key="Mass">1</property>
             </object>
             <object width="0.600" X="8.111" Y="2.691" height="0.600" type="Balloon" ID="Mr.T.Bird" angle="0.000">

--- a/levels/draft/balloons-do-poof.xml
+++ b/levels/draft/balloons-do-poof.xml
@@ -4,7 +4,7 @@
         <title>Balloons do Poof</title>
         <author>Klaas van Gend</author>
         <license>MIT</license>
-        <description>There are two ways to pop a balloon.</description>
+        <description>Push the bowling pins into the goal.</description>
         <date>10/6/10</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/bouncing_balls.xml
+++ b/levels/draft/bouncing_balls.xml
@@ -4,7 +4,7 @@
         <title>Bouncing Balls</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>The second level in the game, and the first level you actually have to put something into the scene.&lt;br>Don't forget to read the Post-it note!</description>
+        <description>The second level in the game, and the first level you actually have to put something into the scene. The goal it to put all balls into the chest.&lt;br&gt;Don't forget to read the Post-it note!</description>
         <date>12/22/09</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/bowling_pin_plays_soccer.xml
+++ b/levels/draft/bowling_pin_plays_soccer.xml
@@ -4,7 +4,7 @@
         <title>Bowling Pin plays soccer...</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>The Bowling Ball cannot kick the Bowling Pin in the goal.</description>
+        <description>Kick the bowling pin into the goal.</description>
         <date>12/17/09</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/bridge-2.xml
+++ b/levels/draft/bridge-2.xml
@@ -4,7 +4,7 @@
         <title>Bridge the Gap II</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>a bowling ball needs to cross a big gap. Let's help crossing. Both ball and Pin need to be on the right!</description>
+        <description>Throw the bowling ball and the bowling pin into the hole on the right.</description>
         <date>March 8, 2010</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/bridge-3.xml
+++ b/levels/draft/bridge-3.xml
@@ -4,7 +4,7 @@
         <title>Bridge the Gap III</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>a tennis ball needs to cross a big gap. Let's help crossing.</description>
+        <description>Throw the tennis ball and the bowling pin into the brown hole.</description>
         <date>March 9, 2010</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/bridge_gap.xml
+++ b/levels/draft/bridge_gap.xml
@@ -4,7 +4,7 @@
         <title>Bridge the Gap I</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>a football needs to cross a big gap. Let's help crossing.</description>
+        <description>Throw the football and the bowling pin into the brown hole.</description>
         <date>March 7, 2010</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/butterfly-on-steroids.xml
+++ b/levels/draft/butterfly-on-steroids.xml
@@ -4,7 +4,7 @@
         <title>Butterfly on steroids</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Another Butterfly and Flower - with a styrofoam wall inbetween.</description>
+        <description>Help the butterfly reach the flower.</description>
         <date>13 May 2010</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/cola-powered-bike.v2.xml
+++ b/levels/draft/cola-powered-bike.v2.xml
@@ -4,7 +4,7 @@
         <title>Cola Powered Bike</title>
         <author>Peter van Ginneken, Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Transfer energy from Steam Engine to Bowling Pin</description>
+        <description>Topple the bowling pin.</description>
         <date>29 may 2010</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/contraption1.xml
+++ b/levels/draft/contraption1.xml
@@ -4,7 +4,7 @@
         <title>Contraption 1</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>This mechanism appears more complex than it actually is.</description>
+        <description>Topple the bowling pin.</description>
         <date>04/23/10</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/contraption2.xml
+++ b/levels/draft/contraption2.xml
@@ -4,7 +4,7 @@
         <title>Contraption 2</title>
         <author>Klaas van Gend, Peter van Ginneken</author>
         <license>GPLv2</license>
-        <description>Levers, Dominoes, Bowling Pins. This one is complex.</description>
+        <description>Topple the bowling pin.</description>
         <date>06/04/10</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/domino_day.xml
+++ b/levels/draft/domino_day.xml
@@ -4,7 +4,7 @@
         <title>Domino Day</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Not affiliated with the yearly event.</description>
+        <description>Topple the bowling pin.</description>
         <date>9/29/09</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/factory.xml
+++ b/levels/draft/factory.xml
@@ -4,7 +4,7 @@
         <title>The Factory</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Something is manufactured here.</description>
+        <description>Topple the bowling pin.</description>
         <date>July 29, 2010</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/find-the-message.v2.xml
+++ b/levels/draft/find-the-message.v2.xml
@@ -4,7 +4,7 @@
         <title>Find the Message...</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>The large rectangular pieces of styrofoam hide a message.</description>
+        <description>Reveal the message hidden by the large rectangular pieces of styrofoam before the butterfly reaches the flower.</description>
         <date>12/21/09, updated 07/02/11</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/geyser.xml
+++ b/levels/draft/geyser.xml
@@ -4,7 +4,7 @@
         <title>Geyser</title>
         <author>Peter van Ginneken, Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>A volley ball must topple a pin from the other end.</description>
+        <description>Topple the bowling pin from the right.</description>
         <date>4/17/10</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/house_of_cards.xml
+++ b/levels/draft/house_of_cards.xml
@@ -4,7 +4,7 @@
         <title>The House of Cards</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>How do YOU demolish a house of cards?</description>
+        <description>Demolish the house of cards.</description>
         <date>12/03/09</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/imperfectbalance.xml
+++ b/levels/draft/imperfectbalance.xml
@@ -4,7 +4,7 @@
         <title>Im Perfect Balance</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>A balancing beam threatens to kill a butterfly. But that's not all that needs fixing.</description>
+        <description>Help the butterfly reach the flower unscratched.</description>
         <date>03/20/10</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/jumping_around-2.xml
+++ b/levels/draft/jumping_around-2.xml
@@ -4,7 +4,7 @@
         <title>Jumping Around II</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>The soccer ball cannot cross a big gap by itself.</description>
+        <description>Topple the bowling pin so it falls into the brown pit.</description>
         <date>May 18, 2011</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/jumping_around.xml
+++ b/levels/draft/jumping_around.xml
@@ -4,7 +4,7 @@
         <title>Jumping Around I</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>a bowling ball needs to cross a big gap. Or does he?</description>
+        <description>Put the pin into the chest.</description>
         <date>March 6, 2010</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/loopings.xml
+++ b/levels/draft/loopings.xml
@@ -4,7 +4,7 @@
         <title>Loopings I</title>
         <author>Thijs van Ginneken, Klaas van Gend</author>
         <license>MIT</license>
-        <description>Looping Looping Looping</description>
+        <description>Topple the bowling pin from the right.</description>
         <date>11/17/10</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/loopings2.xml
+++ b/levels/draft/loopings2.xml
@@ -4,7 +4,7 @@
         <title>Loopings II</title>
         <author>Klaas van Gend</author>
         <license>MIT</license>
-        <description>You'll figure it out.</description>
+        <description>Push the bowling pin into the goal.</description>
         <date>5/26/11</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/pinrack.xml
+++ b/levels/draft/pinrack.xml
@@ -4,7 +4,7 @@
         <title>Pin rack</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Score 100 points by putting the Tennis ball into the right slot.</description>
+        <description>Score 100 points by putting the tennis ball into the right slot.</description>
         <date>Feb 28, 2010</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/poing-poing-poing.xml
+++ b/levels/draft/poing-poing-poing.xml
@@ -4,7 +4,7 @@
         <title>Poing Poing Poing</title>
         <author>Peter van Ginneken, Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Once a Volley Ball jumps across, a Cola bottle will finish it off.</description>
+        <description>Drop the left pin into the left pit, and the right pin into the right pit.</description>
         <date>June 6, 2010</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/poofpoofpoof.xml
+++ b/levels/draft/poofpoofpoof.xml
@@ -4,7 +4,7 @@
         <title>Poof Poof Poof</title>
         <author>Klaas van Gend</author>
         <license>MIT</license>
-        <description>Make all Balloons pop.</description>
+        <description>Make all balloons pop.</description>
         <date>6/3/11</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/save-the-butterfly.xml
+++ b/levels/draft/save-the-butterfly.xml
@@ -4,7 +4,7 @@
         <title>Save the butterfly!</title>
         <author>Klaas van Gend</author>
         <license>MIT</license>
-        <description>save the butterfly, put pin in chest.</description>
+        <description>Save the butterfly, and put the bowling pin into the chest.</description>
         <date>10/11/10</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/skyhook.xml
+++ b/levels/draft/skyhook.xml
@@ -4,7 +4,7 @@
         <title>Skyhook</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>A weight on a chain, hanging on... air?</description>
+        <description>Push both bowling pins towards the styrofoam pyramid.</description>
         <date>Feb 13, 2010</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/spare-the-balloon.xml
+++ b/levels/draft/spare-the-balloon.xml
@@ -4,7 +4,7 @@
         <title>Spare the Balloon</title>
         <author>Klaas van Gend</author>
         <license>MIT</license>
-        <description>Kick the pin.</description>
+        <description>Save the balloon from popping and kick the pin into the goal.</description>
         <date>10/24/10</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/springboard.xml
+++ b/levels/draft/springboard.xml
@@ -4,7 +4,7 @@
         <title>Springboard</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>One ball jumps across the barrier.</description>
+        <description>Kick the bowling pin into the goal.</description>
         <date>04/17/10</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/steam-machine.xml
+++ b/levels/draft/steam-machine.xml
@@ -4,7 +4,7 @@
         <title>Steam Machine</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Look at Steam Machine</description>
+        <description>Put the pin onto the grass.</description>
         <date>22 June 2010</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/styrofoam.xml
+++ b/levels/draft/styrofoam.xml
@@ -4,7 +4,7 @@
         <title>Football in Styrofoam...</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>The soccer ball must kick the pin. But there's something missing.</description>
+        <description>Kick the bowling pin into the goal.</description>
         <date>12/20/09</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/topple-the-other-way.xml
+++ b/levels/draft/topple-the-other-way.xml
@@ -4,7 +4,7 @@
         <title>Topple the other way</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Two bowling balls, the wrong ball kicks the pin.</description>
+        <description>Push the bowling pin towards the green floor.</description>
         <date>03/20/10</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/turn-it-around.xml
+++ b/levels/draft/turn-it-around.xml
@@ -4,7 +4,7 @@
         <title>Turn it around</title>
         <author>Peter van Ginneken, Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>A ball on a bar. Turn it around. Topple the pin.</description>
+        <description>Topple the pin towards the green floor.</description>
         <date>04/17/10</date>
     </levelinfo>
     <toolbox>

--- a/levels/draft/wasteofcola.xml
+++ b/levels/draft/wasteofcola.xml
@@ -4,7 +4,7 @@
         <title>What a waste of cola!</title>
         <author>Klaas van Gend</author>
         <license/>
-        <description>lalalala</description>
+        <description>Push the bowling pin towards the left.</description>
         <date>18-09-11</date>
     </levelinfo>
     <toolbox/>

--- a/levels/draft/zoingandboom.xml
+++ b/levels/draft/zoingandboom.xml
@@ -4,7 +4,7 @@
         <title>Zoing and Boom</title>
         <author>Klaas van Gend</author>
         <license>MIT</license>
-        <description>Imagine the noises in this level! Tip the pin.</description>
+        <description>Topple the bowling pin.</description>
         <date>April 3rd, 2011</date>
     </levelinfo>
     <toolbox>

--- a/levels/elce09/001.xml
+++ b/levels/elce09/001.xml
@@ -4,7 +4,7 @@
         <title>The Butterfly Effect 101</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Hello!&lt;br>Welcome to The Butterfly Effect!&lt;br>&lt;br>This level is a first demonstration. Click PLAY in the top-right and watch the butterfly fly. When it is at the flower, you've won your first level.&lt;br>&lt;br>You might want to click on the Post-it note!</description>
+        <description>Hello!&lt;br&gt;Welcome to The Butterfly Effect!&lt;br&gt;&lt;br&gt;This level is a first demonstration. Click “Play” in the top-right and watch the butterfly fly. When it is at the flower, you've won your first level.&lt;br&gt;&lt;br&gt;You might want to click on the Post-it note!</description>
         <date>11/1/09</date>
     </levelinfo>
     <scene>

--- a/levels/elce09/002.xml
+++ b/levels/elce09/002.xml
@@ -4,7 +4,7 @@
         <title>The Butterfly effect 102</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Level with a small user interaction: a volleyball is in the way... </description>
+        <description>Let the butterfly fly to the flower, but don't hurt it!</description>
         <date>10/10/09</date>
     </levelinfo>
     <toolbox>

--- a/levels/elce09/003.xml
+++ b/levels/elce09/003.xml
@@ -4,7 +4,7 @@
         <title>Marble Boulevard</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Goal: Topple the pin.</description>
+        <description>Topple the bowling pin.</description>
         <date>10/11/09</date>
     </levelinfo>
     <toolbox>

--- a/levels/elce09/004.xml
+++ b/levels/elce09/004.xml
@@ -4,7 +4,7 @@
         <title>Balancing Cola</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Balance your diet? Drink Cola! Goal: Topple the pins.</description>
+        <description>Topple the pins!</description>
         <date>10/9/10</date>
     </levelinfo>
     <toolbox>

--- a/levels/elce09/005.xml
+++ b/levels/elce09/005.xml
@@ -4,7 +4,7 @@
         <title>Blow da Bottle</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Goal: join all bowling pins together.</description>
+        <description>Join all bowling pins together.</description>
         <date>10/11/09</date>
     </levelinfo>
     <toolbox>

--- a/levels/elce09/006.xml
+++ b/levels/elce09/006.xml
@@ -4,7 +4,7 @@
         <title>Coconut instead of Cola</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Can you live from just cola? Let's have some coconuts! Goal: shoot the coconut from the tree.</description>
+        <description>Shoot a coconut from the palm.</description>
         <date>10/11/09</date>
     </levelinfo>
     <toolbox>

--- a/levels/elce09/007.xml
+++ b/levels/elce09/007.xml
@@ -4,7 +4,7 @@
         <title>Double Action</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Two things need to happen at once... Goal: Butterfly to Flower.</description>
+        <description>Help the butterfly reach the flower.</description>
         <date>10/13/09</date>
     </levelinfo>
     <toolbox>

--- a/levels/elce09/brother-plays-penguin-goalie.xml
+++ b/levels/elce09/brother-plays-penguin-goalie.xml
@@ -4,7 +4,7 @@
         <title>My brother likes soccer</title>
         <author>Klaas van Gend</author>
         <license>MIT</license>
-        <description>Kick the soccer ball over the penguin into the bowling pin. Only the pin needs to land into the goal.</description>
+        <description>Kick the soccer ball over the penguin and topple the bowling pin into the goal.</description>
         <date>13 Dec 2015</date>
     </levelinfo>
     <toolbox>

--- a/levels/elce09/brother-plays-soccer.xml
+++ b/levels/elce09/brother-plays-soccer.xml
@@ -4,7 +4,7 @@
         <title>My brother likes soccer</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Soccer is about scoring. Kick the pin in the goal, do not hit the butterfly.</description>
+        <description>Kick the pin in the goal, but do not hit the butterfly.</description>
         <date>10 Feb 2010</date>
     </levelinfo>
     <toolbox>

--- a/levels/games/extreme-tux-racer.xml
+++ b/levels/games/extreme-tux-racer.xml
@@ -4,7 +4,7 @@
         <title>Extreme Tux Racer</title>
         <author>Klaas van Gend</author>
         <license>PD</license>
-        <description>Make Tux descent the ski slope.&lt;br>&lt;br>This level was inspired by the open source Extreme Tux Racer, where Tux has to race down slopes&lt;a href="http://sourceforge.net/projects/extremetuxracer/">http://sourceforge.net/projects/extremetuxracer/&lt;/a></description>
+        <description>Make Tux the penguin descent the ski slope.</description>
         <date>March 6, 2014</date>
     </levelinfo>
     <toolbox>

--- a/levels/games/supertuxkart.xml
+++ b/levels/games/supertuxkart.xml
@@ -4,7 +4,7 @@
         <title>Loopings</title>
         <author>Klaas van Gend</author>
         <license>MIT</license>
-        <description>Looping in Looping in looping... &lt;br>Poor Tux is late for his race. &lt;br>Get him to the cone fast!&lt;br>&lt;br>This level is 'inspired' by SuperTuxKart, the famous open source kart game featuring all open source mascots to race in beautifully designed tracks.&lt;a href="http://supertuxkart.sourceforge.net/">http://supertuxkart.sourceforge.net/&lt;/a> </description>
+        <description>Help Tux the racing penguin get to the cone fast!</description>
         <date>March 16, 2014</date>
     </levelinfo>
     <toolbox>

--- a/levels/jumpingjack/party-at-office.xml
+++ b/levels/jumpingjack/party-at-office.xml
@@ -4,7 +4,7 @@
         <title>Party at the office</title>
         <author>Klaas van Gend</author>
         <license>GPLv2</license>
-        <description>Jumping Jack celebrates a party at the office. Isn't that fun?</description>
+        <description>Deliver the birthday present to Jumping Jack.</description>
         <date>Jul 08, 2010 - Oct 23, 2010</date>
     </levelinfo>
     <toolbox>

--- a/levels/picnic/picnic-0.xml
+++ b/levels/picnic/picnic-0.xml
@@ -4,7 +4,7 @@
         <title>Tent</title>
         <author>Klaas van Gend</author>
         <license>Public Domain</license>
-        <description>Hah! Ad and Lies want to put up the tent.&lt;br&gt;&lt;br&gt;Let's make a joke and tear down the tent poles!</description>
+        <description>Tear down the tent poles!</description>
         <date>5/15/12</date>
     </levelinfo>
     <toolbox>

--- a/levels/picnic/picnic-2.xml
+++ b/levels/picnic/picnic-2.xml
@@ -4,7 +4,7 @@
         <title>Pétanque</title>
         <author>Klaas van Gend</author>
         <license>PD</license>
-        <description>Toss both balls ("boules") so they end up very close to "le but" - just like "la vraie Pétanque".</description>
+        <description>Toss both Pétanque balls so they end up very close to the tennis ball.</description>
         <date>5/7/12</date>
     </levelinfo>
     <toolbox>

--- a/levels/picnic/picnic-3.xml
+++ b/levels/picnic/picnic-3.xml
@@ -4,7 +4,7 @@
         <title>Hole-in-One</title>
         <author>Klaas van Gend</author>
         <license>PD</license>
-        <description>Mini Golf&lt;br>After the ball is eaten by the monkey, make it come out of the monkey's rear end into the chest.</description>
+        <description>Put the Pétanque ball into the chest.</description>
         <date>4/25/12</date>
     </levelinfo>
     <toolbox>


### PR DESCRIPTION
Fixes issue #67.
https://github.com/kaa-ching/tbe/issues/67

I rewrote the level descriptions so they are a bit more spot-on, and clearer to understand and always clearly state the goal, and I threw out (most) uninteresting bla-bla, like T-Dose 2010 (Frankly, who cares? :D). At least I hope so, but see for yourself.
I also did some levels not included in the in-game level list, but I ignored the test levels for obvious reasons.

I also quickly proofread the diff and tested the levels included in the level list to make sure I did not break anything. I did not found crashes.