### PR TITLE
Fix Qt5 build problems on Mac OS X

### DIFF
--- a/src/control/ViewObjectActionDectorator.cpp
+++ b/src/control/ViewObjectActionDectorator.cpp
@@ -24,7 +24,7 @@
 #include "ViewObject.h"
 
 #include <QtCore/QDebug>
-#include <QtGui/QGraphicsSceneMouseEvent>
+#include <QGraphicsSceneMouseEvent>
 #include <QtGui/QPainter>
 
 
@@ -88,7 +88,7 @@ ViewObjectActionDecorator::setViewObject(ViewObjectPtr aParentPtr)
     // we need to have the same size as our parent
     QRectF parSize = aParentPtr->boundingRect();
     QRectF mySize = boundingRect();
-    scale(parSize.width()/mySize.width(),parSize.height()/mySize.height());
+    setTransform(QTransform::fromScale(parSize.width()/mySize.width(),parSize.height()/mySize.height()), true);
     setFlags(ItemIsMovable);
     setVisible(false);
 }


### PR DESCRIPTION
Hi @kaa-ching,

With two fixes in one file I'm able to build the Qt5 build on Mac OS X.

After building the can't be started automagically yet, some simple restructuring is needed but I don't have the time now to fix it. But when doing the needed changes manually I'm able to start the Qt5 tbe executable on Mac OS X. Also clicking on tbe.app in the Mac OS X Finder works so the layout I created manually is sufficient for that.

Next steps for Mac OS X when the build fix is integrated:
1) update CMakeLists.txt to create the now manually created structure
2) update the Mac OS X build wiki page so the instructions are correct for others to reproduce
3) create a .dmg file that also includes the Qt5 libs and needed support files so it can be distributed to other Mac OS X users for testing
4) create an application icon in the Mac format
5) Improve the generated .dmg file to include a link to the Applications folder and a nice background image

When step three is finished the generated .dmg file can be released for alpha testing by a couple of people.

Thanks for the great progress the last week, I'm going back to cleaning up my office and prepare for the movement of everything to a new office location in 2 weeks. Would be nice to go to Brussels for FOSDEM and have the 5 steps above ready.

Have a nice weekend,

Aschwin