### PR TITLE
Fixed: warning: '...' overrides a member function but is not marked '…

### DIFF
--- a/src/view/ViewWorld.h
+++ b/src/view/ViewWorld.h
@@ -114,18 +114,18 @@ private:
 	// the below is for the Debug drawing of Box2D
 protected:
 	/// Draw a closed polygon provided in CCW order.
-	virtual void DrawPolygon(const b2Vec2* vertices, int32 vertexCount, const b2Color& color);
+	virtual void DrawPolygon(const b2Vec2* vertices, int32 vertexCount, const b2Color& color) override;
 	/// Draw a solid closed polygon provided in CCW order.
-	virtual void DrawSolidPolygon(const b2Vec2* vertices, int32 vertexCount, const b2Color& color);
+	virtual void DrawSolidPolygon(const b2Vec2* vertices, int32 vertexCount, const b2Color& color) override;
 	/// Draw a circle.
-	virtual void DrawCircle(const b2Vec2& center, float32 radius, const b2Color& color);
+	virtual void DrawCircle(const b2Vec2& center, float32 radius, const b2Color& color) override;
 	/// Draw a solid circle.
-	virtual void DrawSolidCircle(const b2Vec2& center, float32 radius, const b2Vec2& axis, const b2Color& color);
+	virtual void DrawSolidCircle(const b2Vec2& center, float32 radius, const b2Vec2& axis, const b2Color& color) override;
 	/// Draw a line segment.
-	virtual void DrawSegment(const b2Vec2& p1, const b2Vec2& p2, const b2Color& color);
+	virtual void DrawSegment(const b2Vec2& p1, const b2Vec2& p2, const b2Color& color) override;
 	/// Draw a transform. Choose your own length scale.
 	/// @param xf a transform.
-	virtual void DrawTransform(const b2Transform& xf);
+	virtual void DrawTransform(const b2Transform& xf) override;
 
 	const static int theMaxNumberOfGraphicsListElements;
 	typedef QList<QGraphicsItem*> GraphicsList;


### PR DESCRIPTION
…override' [-Winconsistent-missing-override]