### PR TITLE
Fix numbers being saved with locale in mind #66

### DIFF
--- a/src/loadsave/AbstractObjectSerializer.cpp
+++ b/src/loadsave/AbstractObjectSerializer.cpp
@@ -39,16 +39,6 @@ AbstractObjectSerializer::AbstractObjectSerializer(const AbstractObjectPtr anObj
 }
 
 
-QString AbstractObjectSerializer::floatToString(float aValue) const
-{
-	// HACK HACK - yes, I'm aware I'm using C-style tricks here
-	// to work around the i18n issues that QT provides me with :-(
-	char myString[256];
-	snprintf(myString,200, "%-2.3f", aValue);
-	return QString(myString);
-}
-
-
 void
 AbstractObjectSerializer::serialize(QDomElement* aParent) const
 {
@@ -62,11 +52,11 @@ AbstractObjectSerializer::serialize(QDomElement* aParent) const
 	// TODO: only save values that are different from default
 	QDomElement myNode = aParent->ownerDocument().createElement(theObjectString);
 	myNode.setAttribute(theTypeAttributeString, theAbstractObjectPtr->getInternalName());
-	myNode.setAttribute(theXAttributeString, floatToString(theAbstractObjectPtr->getOrigCenter().x));
-	myNode.setAttribute(theYAttributeString, floatToString(theAbstractObjectPtr->getOrigCenter().y));
-	myNode.setAttribute(theAngleAttributeString, floatToString(theAbstractObjectPtr->getOrigCenter().angle));
-	myNode.setAttribute(theWidthAttributeString, floatToString(theAbstractObjectPtr->getTheWidth()));
-	myNode.setAttribute(theHeightAttributeString, floatToString(theAbstractObjectPtr->getTheHeight()));
+	myNode.setAttribute(theXAttributeString, QString::number(theAbstractObjectPtr->getOrigCenter().x));
+	myNode.setAttribute(theYAttributeString, QString::number(theAbstractObjectPtr->getOrigCenter().y));
+	myNode.setAttribute(theAngleAttributeString, QString::number(theAbstractObjectPtr->getOrigCenter().angle));
+	myNode.setAttribute(theWidthAttributeString, QString::number(theAbstractObjectPtr->getTheWidth()));
+	myNode.setAttribute(theHeightAttributeString, QString::number(theAbstractObjectPtr->getTheHeight()));
 	if (theAbstractObjectPtr->getID().isEmpty()==false)
 		myNode.setAttribute(theIDAttributeString, theAbstractObjectPtr->getID());
 

--- a/src/loadsave/AbstractObjectSerializer.h
+++ b/src/loadsave/AbstractObjectSerializer.h
@@ -60,13 +60,6 @@ public:
 											   bool isMovable,
 											   bool isXYMandatory);
 
-	/** returns a string representation of the float
-	 *  - maximum 3 digits
-	 *  - always a dot as decimal separator
-	 *  @param aValue the float to convert
-	 *  @returns a QString with the string representation of aValue.
-	 */
-	QString floatToString(float aValue) const;
 
 private:
 	/// constructor only called by AbstractObject

--- a/src/loadsave/BackgroundSerializer.cpp
+++ b/src/loadsave/BackgroundSerializer.cpp
@@ -88,16 +88,6 @@ BackgroundSerializer::createObjectFromDom(const QDomNode& q, Background* aBGPtr)
 }
 
 
-QString BackgroundSerializer::floatToString(float aValue)
-{
-	// HACK HACK - yes, I'm aware I'm using C-style tricks here
-	// to work around the i18n issues that QT provides me with :-(
-	char myString[56];
-	snprintf(myString,50, "%2.2f", aValue);
-	return QString(myString);
-}
-
-
 void
 BackgroundSerializer::serialize(QDomElement* aParent, Background* aBackgroundPtr)
 {
@@ -107,8 +97,8 @@ BackgroundSerializer::serialize(QDomElement* aParent, Background* aBackgroundPtr
 	{
 		QDomElement myImageName = aParent->ownerDocument().createElement(theImageString);
 		myImageName.setAttribute(theNameString, aBackgroundPtr->theImageName);
-		myImageName.setAttribute(theImgHRepeatString, floatToString(aBackgroundPtr->theImageHRepeat));
-		myImageName.setAttribute(theImgVRepeatString, floatToString(aBackgroundPtr->theImageVRepeat));
+		myImageName.setAttribute(theImgHRepeatString, QString::number(aBackgroundPtr->theImageHRepeat));
+		myImageName.setAttribute(theImgVRepeatString, QString::number(aBackgroundPtr->theImageVRepeat));
 		myBackground.appendChild(myImageName);
 	}
 
@@ -118,13 +108,13 @@ BackgroundSerializer::serialize(QDomElement* aParent, Background* aBackgroundPtr
 		foreach(Background::GradientStop myGS, aBackgroundPtr->theBackgroundGradient)
 		{
 			QString myGradientValue = QString("%1;%2;%3;%4")
-									  .arg(floatToString(myGS.theR))
-									  .arg(floatToString(myGS.theG))
-									  .arg(floatToString(myGS.theB))
-									  .arg(floatToString(myGS.theAlpha));
+									  .arg(QString::number(myGS.theR))
+									  .arg(QString::number(myGS.theG))
+									  .arg(QString::number(myGS.theB))
+									  .arg(QString::number(myGS.theAlpha));
 
 			QDomElement myGradient = aParent->ownerDocument().createElement(theGradientString);
-			myGradient.setAttribute(thePositionString, floatToString(myGS.thePosition));
+			myGradient.setAttribute(thePositionString, QString::number(myGS.thePosition));
 			QDomText myT = aParent->ownerDocument().createTextNode(myGradientValue);
 			myGradient.appendChild(myT);
 			myBackground.appendChild(myGradient);

--- a/src/loadsave/BackgroundSerializer.h
+++ b/src/loadsave/BackgroundSerializer.h
@@ -50,14 +50,6 @@ public:
 	 */
 	static QString createObjectFromDom(const QDomNode& q, Background* aBGPtr);
 
-	/** returns a string representation of the float
-	 *  - maximum 2 digits
-	 *  - always a dot as decimal separator
-	 *  @param aValue the float to convert
-	 *  @returns a QString with the string representation of aValue.
-	 */
-	static QString floatToString(float aValue);
-
 private:
 	/// constructor only called by Background
 	BackgroundSerializer(const Background* anObjectPtr);

--- a/src/loadsave/Level.cpp
+++ b/src/loadsave/Level.cpp
@@ -474,8 +474,8 @@ bool Level::save(const QString& aFileName)
     myRoot.appendChild(mySceneParent);
     // ... add scenesize
     QDomElement mySceneSizeNode = myDocument.createElement(theSceneSizeString);
-    mySceneSizeNode.setAttribute(theWidthAttributeString, theWorldPtr->theWorldWidth);
-    mySceneSizeNode.setAttribute(theHeightAttributeString, theWorldPtr->theWorldHeight);
+    mySceneSizeNode.setAttribute(theWidthAttributeString, QString::number(theWorldPtr->theWorldWidth));
+    mySceneSizeNode.setAttribute(theHeightAttributeString, QString::number(theWorldPtr->theWorldHeight));
     mySceneParent.appendChild(mySceneSizeNode);
     // ... add the predefined elements
     QDomElement myPredefinedParent = myDocument.createElement(thePredefinedString);

--- a/src/loadsave/ToolboxGroupSerializer.cpp
+++ b/src/loadsave/ToolboxGroupSerializer.cpp
@@ -97,7 +97,7 @@ QDomElement ToolboxGroupSerializer::serialize(QDomDocument& aDomDocument, Toolbo
 {
     // write the properties of the toolboxgroup itself
     QDomElement myToolboxNode = aDomDocument.createElement(theToolboxItemString);
-    myToolboxNode.setAttribute(theCountString, aToolboxGroupPtr->count());
+    myToolboxNode.setAttribute(theCountString, QString::number(aToolboxGroupPtr->count()));
     myToolboxNode.setAttribute(theNameString, aToolboxGroupPtr->theGroupName);
     // write the properties of (one of the) object(s) in the toolboxgroup
     const AbstractObjectSerializer* myAOSerializerPtr = aToolboxGroupPtr->first()->getSerializer();


### PR DESCRIPTION
This fixes the locale issue as complained about in issue #66.

The problem was that `QDomElement::setAttribute(const QString & name, double value)` is called, and according to Qt doc it formats `value` according to the current locale.

https://doc.qt.io/qt-5/qdomelement.html#setAttribute-6

Yes, this was a very WTF moment as I have seen it in the docs, lol. The solution in my eyes is use `void QDomElement::setAttribute(const QString & name, const QString & value)` instead and convert the number to a string with `QString::number`.

https://doc.qt.io/qt-5/qstring.html#number

I also got rid of the two HACK HACK `floatToString` functions that way. :-)

I have tested it by loading two levels and saving them again under the German locale and no more commans in the numbers. But please also do a quick test for yourselves, just to be sure.