### PR TITLE
Clean up the wedge confusion

### DIFF
--- a/levels/draft/balloons-do-poof.xml
+++ b/levels/draft/balloons-do-poof.xml
@@ -37,7 +37,8 @@
             </object>
             <object width="0.1" X="0.5" Y="1.05" height="1.9" type="Wall" angle="0"/>
             <object width="0.21" X="0.7" Y="1.86" height="0.21" type="VolleyBall" angle="0"/>
-            <object width="0.3" X="0.7" Y="0.7" height="0.3" type="RightRamp" angle="0">
+            <object width="0.3" X="0.7" Y="0.7" height="0.3" type="RightWedge" angle="0">
+                <tooltip>A light movable wedge made out of styrofoam.</tooltip>
                 <property key="Bounciness">0.6</property>
                 <property key="ImageName">styrofoam-right</property>
                 <property key="Mass">0.2</property>

--- a/levels/draft/butterflies_of_doom.xml
+++ b/levels/draft/butterflies_of_doom.xml
@@ -19,14 +19,14 @@
         <toolboxitem count="1" name="Left ramp">
             <object width="1.000" X="0.756" Y="1.984" height="1.000" type="LeftRamp" angle="0.000"/>
         </toolboxitem>
-        <toolboxitem count="1" name="Long left wedge">
-            <object width="0.575" X="2.063" Y="1.475" height="0.186" type="LeftWedge" angle="0.000"/>
+        <toolboxitem count="1" name="Long left fixed wedge">
+            <object width="0.575" X="2.063" Y="1.475" height="0.186" type="LeftFixedWedge" angle="0.000"/>
         </toolboxitem>
-        <toolboxitem count="1" name="Right wedge">
-            <object width="0.653" X="0.303" Y="1.380" height="0.696" type="RightWedge" angle="0.000"/>
+        <toolboxitem count="1" name="Right fixed wedge">
+            <object width="0.653" X="0.303" Y="1.380" height="0.696" type="RightFixedWedge" angle="0.000"/>
         </toolboxitem>
-        <toolboxitem count="1" name="Short left wedge">
-            <object width="0.286" X="5.412" Y="0.341" height="0.311" type="LeftWedge" angle="0.000"/>
+        <toolboxitem count="1" name="Short left fixed wedge">
+            <object width="0.286" X="5.412" Y="0.341" height="0.311" type="LeftFixedWedge" angle="0.000"/>
         </toolboxitem>
         <toolboxitem count="1" name="Small quarter arc">
             <object width="0.461" X="1.080" Y="0.736" height="0.404" type="QuarterArc80">

--- a/levels/draft/contraption1.xml
+++ b/levels/draft/contraption1.xml
@@ -8,7 +8,7 @@
         <date>04/23/10</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem count="2" name="Wedge \">
+        <toolboxitem count="2" name="Right birch wedge">
             <object width="0.4" X="0.30" Y="0.35" height="0.3" type="RightWedge">
                 <property key="Bounciness">0.3</property>
                 <property key="Mass">2.0</property>
@@ -115,7 +115,8 @@
                 <property key="ImageName">used_wood_bar</property>
                 <property key="Friction">0.4</property>
             </object>
-            <object width="0.3" X="4.45" Y="2.1" height="0.6" type="RightRamp" angle="3.14">
+            <object width="0.3" X="4.45" Y="2.1" height="0.6" type="RightFixedWedge" angle="3.14">
+                <tooltip>This styrofoam wedge has been glued to the wall.</tooltip>
                 <property key="ImageName">styrofoam-right</property>
                 <property key="Bounciness">0.1</property>
             </object>

--- a/levels/draft/contraption2.xml
+++ b/levels/draft/contraption2.xml
@@ -8,8 +8,9 @@
         <date>06/04/10</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem count="1" name="Ramp \">
-            <object width="0.6" height="0.35" type="RightRamp">
+        <toolboxitem count="1" name="Right styrofoam wedge">
+            <object width="0.6" height="0.35" type="RightWedge">
+                <tooltip>A light and movable wedge made out of styrofoam.</tooltip>
                 <property key="ImageName">styrofoam-right</property>
                 <property key="Bounciness">0.3</property>
                 <property key="Mass">1.0</property>

--- a/levels/draft/creativity.xml
+++ b/levels/draft/creativity.xml
@@ -31,7 +31,7 @@
         <toolboxitem name="Floor" count="1">
             <object Y="0" type="Floor" height="0.1" angle="0" width="1" X="0"/>
         </toolboxitem>
-        <toolboxitem name="Left wedge" count="1">
+        <toolboxitem name="Left birch wedge" count="1">
             <object Y="0" type="LeftWedge" height="0.5" angle="0" width="0.5" X="0"/>
         </toolboxitem>
         <toolboxitem name="Right ramp" count="1">

--- a/levels/draft/domino_chest.xml
+++ b/levels/draft/domino_chest.xml
@@ -20,11 +20,11 @@
                 <property key="Rotatable">true</property>
             </object>
         </toolboxitem>
-        <toolboxitem name="Left wedge" count="1">
-            <object angle="0.000" type="LeftWedge" X="1.266" height="0.288" Y="4.582" width="0.656"/>
+        <toolboxitem name="Left fixed wedge" count="1">
+            <object angle="0.000" type="LeftFixedWedge" X="1.266" height="0.288" Y="4.582" width="0.656"/>
         </toolboxitem>
-        <toolboxitem name="Right wedge" count="1">
-            <object angle="0.000" type="RightWedge" X="0.718" height="0.311" Y="5.103" width="1.061"/>
+        <toolboxitem name="Right fixed wedge" count="1">
+            <object angle="0.000" type="RightFixedWedge" X="0.718" height="0.311" Y="5.103" width="1.061"/>
         </toolboxitem>
         <toolboxitem name="Soccer ball" count="1">
             <object angle="0.000" type="SoccerBall" X="0.000" height="0.220" Y="0.000" width="0.220"/>

--- a/levels/draft/find-the-message.v2.xml
+++ b/levels/draft/find-the-message.v2.xml
@@ -14,7 +14,7 @@
         <toolboxitem count="1" name="Spring">
             <object width="0.400" X="2.399" Y="2.665" height="0.200" type="Spring" angle="0.000"/>
         </toolboxitem>
-        <toolboxitem count="2" name="Wood Wedge">
+        <toolboxitem count="2" name="Birch wedge">
             <object width="0.350" height="0.350" type="RightWedge">
                 <property key="Rotatable">true</property>
                 <property key="Mass">1.0</property>

--- a/levels/draft/imperfectbalance.xml
+++ b/levels/draft/imperfectbalance.xml
@@ -11,8 +11,9 @@
         <toolboxitem count="1" name="Bowling Ball">
             <object type="BowlingBall"/>
         </toolboxitem>
-        <toolboxitem count="1" name="Wedge \">
+        <toolboxitem count="1" name="Right styrofoam wedge">
             <object width="0.6" height="0.3" type="RightWedge">
+                <tooltip>A light movable wedge made out of styrofoam.</tooltip>
                 <property key="ImageName">styrofoam-right</property>
                 <property key="Bounciness">0.1</property>
                 <property key="Mass">0.3</property>

--- a/levels/draft/maze.xml
+++ b/levels/draft/maze.xml
@@ -8,10 +8,10 @@
         <date>29.01.16</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem count="2" name="Left Wedge">
+        <toolboxitem count="2" name="Left fixed wedge">
             <object angle="0.000" type="LeftFixedWedge" X="0.000" height="0.250" width="0.250" Y="0.000"/>
         </toolboxitem>
-        <toolboxitem count="1" name="Right Wedge">
+        <toolboxitem count="1" name="Right fixed wedge">
             <object angle="0.000" type="RightFixedWedge" X="3.768" height="0.250" width="0.250" Y="3.207"/>
         </toolboxitem>
     </toolbox>

--- a/levels/draft/poofpoofpoof.xml
+++ b/levels/draft/poofpoofpoof.xml
@@ -11,7 +11,7 @@
         <toolboxitem count="1" name="Saw Blade">
             <object width="0.380" X="0.555" Y="2.466" height="0.380" type="CircularSaw" angle="0.000"/>
         </toolboxitem>
-        <toolboxitem count="1" name="Wedge /">
+        <toolboxitem count="1" name="Left birch wedge">
             <object width="0.400" height="0.200" type="LeftWedge">
                 <property key="Mass">0.6</property>
             </object>

--- a/levels/draft/styrofoam.xml
+++ b/levels/draft/styrofoam.xml
@@ -21,54 +21,61 @@
     <scene>
         <scenesize width="4.5" height="3"/>
         <predefined>
-            <object width="0.100" X="0.050" Y="1.450" height="2.700" type="RectObject" angle="0.000">
+            <object width="0.100" X="0.050" Y="1.450" height="2.700" type="Floor" angle="0.000">
                 <property key="Bounciness">0.05</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
-            <object width="0.100" X="4.450" Y="1.450" height="2.700" type="RectObject" angle="0.000">
+            <object width="0.100" X="4.450" Y="1.450" height="2.700" type="Floor" angle="0.000">
                 <property key="Bounciness">0.05</property>
-                <property key="ImageName">used_wood_bar</property>
             </object>
             <object width="0.220" X="0.400" Y="2.700" height="0.220" type="SoccerBall" angle="0.000"/>
             <object width="2.000" X="3.400" Y="2.650" height="0.100" type="Floor" angle="0.000"/>
-            <object width="2.000" X="3.400" Y="2.350" height="0.500" type="RightRamp" angle="3.140">
+            <object width="2.000" X="3.400" Y="2.350" height="0.500" type="RightFixedWedge" angle="3.140">
+                <tooltip>This styrofoam wedge has been glued to the wall.</tooltip>
                 <property key="Bounciness">0.6</property>
                 <property key="ImageName">styrofoam-right</property>
             </object>
-            <object width="3.800" X="2.000" Y="2.050" height="0.500" type="RightRamp" angle="0.000">
+            <object width="3.800" X="2.000" Y="2.050" height="0.500" type="RightFixedWedge" angle="0.000">
+                <tooltip>This styrofoam wedge has been glued to the wall.</tooltip>
                 <property key="Bounciness">0.6</property>
                 <property key="ImageName">styrofoam-right</property>
             </object>
             <object width="3.800" X="2.000" Y="1.750" height="0.100" type="Floor" angle="0.000"/>
             <object width="0.600" X="4.100" Y="1.500" height="0.400" type="LeftWedge" angle="0.000">
+                <tooltip>A light movable wedge made out of styrofoam.</tooltip>
                 <property key="Bounciness">0.6</property>
                 <property key="ImageName">styrofoam-left</property>
                 <property key="Mass">0.6</property>
             </object>
             <object width="1.000" X="3.900" Y="1.150" height="0.300" type="RectObject" angle="0.000">
+                <tooltip>Styrofoam blocks are light and durable.</tooltip>
                 <property key="Bounciness">0.6</property>
                 <property key="ImageName">styrofoam</property>
             </object>
             <object width="3.800" X="2.500" Y="0.950" height="0.100" type="Floor" angle="0.000"/>
             <object width="0.400" X="0.800" Y="1.150" height="0.250" type="LeftWedge" angle="0.000">
+                <tooltip>A light movable wedge made out of styrofoam.</tooltip>
                 <property key="Bounciness">0.5</property>
                 <property key="ImageName">styrofoam-left</property>
                 <property key="Mass">0.9</property>
             </object>
-            <object width="0.400" X="0.300" Y="1.550" height="0.300" type="LeftRamp" angle="3.140">
+            <object width="0.400" X="0.300" Y="1.550" height="0.300" type="LeftFixedWedge" angle="3.140">
+                <tooltip>This styrofoam wedge has been glued to the wall.</tooltip>
                 <property key="Bounciness">0.6</property>
                 <property key="ImageName">styrofoam-left</property>
             </object>
             <object width="0.600" X="0.400" Y="0.700" height="0.400" type="RightWedge" angle="0.000">
+                <tooltip>A light movable wedge made out of styrofoam.</tooltip>
                 <property key="Bounciness">0.6</property>
                 <property key="ImageName">styrofoam-right</property>
                 <property key="Mass">0.6</property>
             </object>
             <object width="1.000" X="0.600" Y="0.250" height="0.300" type="RectObject" angle="0.000">
+                <tooltip>Styrofoam blocks are light and durable.</tooltip>
                 <property key="Bounciness">0.5</property>
                 <property key="ImageName">styrofoam</property>
             </object>
             <object width="0.400" X="3.400" Y="0.250" height="0.250" type="RightWedge" angle="0.000">
+                <tooltip>A light movable wedge made out of styrofoam.</tooltip>
                 <property key="Bounciness">0.6</property>
                 <property key="ImageName">styrofoam-right</property>
                 <property key="Mass">0.9</property>
@@ -80,7 +87,7 @@
                 <property key="ImageName">goal-scenery</property>
                 <property key="ZValue">4</property>
             </object>
-            <object width="0.150" X="4.300" Y="0.450" height="0.700" type="RightRamp" angle="3.140">
+            <object width="0.150" X="4.300" Y="0.450" height="0.700" type="RightFixedWedge" angle="3.140">
                 <property key="ImageName">Empty</property>
             </object>
             <object width="4.500" X="2.250" Y="0.050" height="0.100" type="Floor" angle="0.000"/>

--- a/levels/draft/wedge_land.xml
+++ b/levels/draft/wedge_land.xml
@@ -8,13 +8,13 @@
         <date>04.02.16</date>
     </levelinfo>
     <toolbox>
-        <toolboxitem name="Left wedge" count="2">
-            <object type="LeftWedge" angle="0" width="0.68" height="0.28" X="0" Y="0">
+        <toolboxitem name="Left fixed wedge" count="2">
+            <object type="LeftFixedWedge" angle="0" width="0.68" height="0.28" X="0" Y="0">
                 <property key="Resizable">totalresize</property>
             </object>
         </toolboxitem>
-        <toolboxitem name="Right wedge" count="3">
-            <object type="RightWedge" angle="0" width="0.68" height="0.28" X="0" Y="0">
+        <toolboxitem name="Right fixed wedge" count="3">
+            <object type="RightFixedWedge" angle="0" width="0.68" height="0.28" X="0" Y="0">
                 <property key="Resizable">totalresize</property>
             </object>
         </toolboxitem>
@@ -49,9 +49,9 @@
             <object ID="IWantToGoRight2" type="Pingus" angle="0" width="0.28" height="0.28" X="5.90858" Y="4.01665"/>
             <object ID="ChestBall" type="VolleyBall" angle="0" width="0.21" height="0.21" X="4.22159" Y="3.99721"/>
             <object ID="PitBall1" type="SoccerBall" angle="0" width="0.22" height="0.22" X="4.22522" Y="3.19825"/>
-            <object type="LeftWedge" angle="0" width="0.68069" height="0.69795" X="9.20739" Y="2.02724"/>
+            <object type="LeftFixedWedge" angle="0" width="0.68069" height="0.69795" X="9.20739" Y="2.02724"/>
             <object type="Floor" angle="0" width="0.925563" height="0.1" X="8.0925" Y="2.28306"/>
-            <object type="RightWedge" angle="0" width="0.64617" height="0.300971" X="5.93662" Y="1.27909"/>
+            <object type="RightFixedWedge" angle="0" width="0.64617" height="0.300971" X="5.93662" Y="1.27909"/>
             <object type="Scenery" angle="0" width="1.01194" height="0.701451" X="0.998717" Y="0.574777">
                 <property key="ImageName">basket</property>
                 <property key="ZValue">1</property>


### PR DESCRIPTION
This cleans up some of the \*Wedge/\*FixedWedge-related mess in the levels.


* Ramps which should be wedges are now actually wedges
* My levels which have been built while \*Wedge was still fixed have been changed to use the fixed wedge again (where it was neccessary)—otherwise they would be (probably) unsolvable
* Fixes some incorrect tooltips (esp. for styrofoam)
* I looked at all the included levels, so I think this fixes parts 2 and 3 of issue #113
* Fixes ramp-as-a-wedge in Contraption 2 (complained about in #34)


I made 2 commits, one for my levels, the other one for all the other levels to make cherry-picking easier (if you need to).

I noticed that Hole-in-One uses a birch wedge right now. It is movable. Is this intentional? I found solutions for both variants (birch vs fixed wedge). I think the current version is the better one, so I did not touch Hole-in-One.