### PR TITLE
Fix compilation warnings on Mac OS X: warning: '<...>' overrides a me…

### DIFF
--- a/src/model/ColaMintBottle.h
+++ b/src/model/ColaMintBottle.h
@@ -34,7 +34,7 @@ public:
 
 	/// @returns true if the object should not surive a World::deletePhysicsWorld()
 	/// overridden from AbstractObject
-	virtual bool isTemp() const
+	virtual bool isTemp() const override
 	{ return true; }
 
     /** sets all parameters of the splatter
@@ -47,7 +47,7 @@ public:
 				qreal aVelocity, qreal aSplatterMass);
 
 	/// overridden from AbstractObject - we want reports on NormalImpulse
-	virtual bool isInterestedInNormalImpulse(void)
+	virtual bool isInterestedInNormalImpulse(void) override
 	{ return true; }
 
 	/** overridden from AbstractObject - if we have an impulse, we hit something
@@ -89,7 +89,7 @@ public:
 	void setBottleStatus(BottleStatus aNewStat);
 
 	/// let's mis-use deletePhysicsObject to reset our object state
-	virtual void deletePhysicsObject(void);
+	virtual void deletePhysicsObject(void) override;
 
 	/// @returns the current bottle state
 	BottleStatus getBottleStatus(void)
@@ -97,11 +97,11 @@ public:
 
 	/// overridden from AbstractObject to allow representation of the states
 	/// @returns: returns a numerical index similar to the state
-	virtual unsigned int getImageIndex(void) const
+	virtual unsigned int getImageIndex(void) const override
 	{ return theBottleStatus; }
 
 	/// overridden from AbstractObject - we want reports on NormalImpulse
-	virtual bool isInterestedInNormalImpulse(void)
+	virtual bool isInterestedInNormalImpulse(void) override
 	{ return true; }
 
 	/** overridden from AbstractObject - we want to receive
@@ -112,11 +112,11 @@ public:
                                    AbstractObject* anOtherObjectPtr) override;
 
 	/// overridden from AbstractObject because this class wants to register for callbacks
-	virtual void createPhysicsObject(void);
+	virtual void createPhysicsObject(void) override;
 
 private:
 	/// implemented from SimStepCallbackInterface
-	virtual void callbackStep (qreal aTimeStep, qreal aTotalTime);
+	virtual void callbackStep (qreal aTimeStep, qreal aTotalTime) override;
 
 	/** generate a new Cola splatter
 	 *  @param aSequenceNr the sequence number of the splatter

--- a/src/model/PolyObject.h
+++ b/src/model/PolyObject.h
@@ -54,7 +54,7 @@ public:
 	//
 
 	/// returns the Name of the object.
-	virtual const QString getName ( ) const
+	virtual const QString getName ( ) const override
 	{	return theNameString;	}
 
 	/// child objects must specify what type of body they are
@@ -64,7 +64,7 @@ public:
 
 	/// parse all properties
 	/// partially overridden from AbstractObject
-	virtual void  parseProperties(void);
+	virtual void  parseProperties(void) override;
 
 protected:
 	/// TODO/FIXME: see same notes in RectObject...

--- a/src/model/TriggerExplosion.h
+++ b/src/model/TriggerExplosion.h
@@ -302,11 +302,11 @@ public:
 
     /// @returns true if the object should not surive a World::deletePhysicsWorld()
 	/// overridden from AbstractObject
-	virtual bool isTemp() const
+	virtual bool isTemp() const override
 	{ return true; }
 
 	/// overridden from AbstractObject - we want reports on NormalImpulse
-	virtual bool isInterestedInNormalImpulse(void)
+	virtual bool isInterestedInNormalImpulse(void) override
 	{ return true; }
 
 	/** overridden from AbstractObject - if we have an impulse, we hit something


### PR DESCRIPTION
…mber function but is not marked 'override' [-Winconsistent-missing-override]